### PR TITLE
Add hex and binary notation

### DIFF
--- a/blots-core/src/expressions.rs
+++ b/blots-core/src/expressions.rs
@@ -1922,10 +1922,10 @@ fn pairs_to_expr_inner(pairs: Pairs<Rule>, preserve_comments: bool) -> AnyhowRes
                     let num_str = primary.as_str();
                     let value = if num_str.starts_with("0b") || num_str.starts_with("-0b") || num_str.starts_with("+0b") {
                         // Binary number
-                        let (sign, digits) = if num_str.starts_with("-0b") {
-                            (-1.0, &num_str[3..])
-                        } else if num_str.starts_with("+0b") {
-                            (1.0, &num_str[3..])
+                        let (sign, digits) = if let Some(stripped) = num_str.strip_prefix("-0b") {
+                            (-1.0, stripped)
+                        } else if let Some(stripped) = num_str.strip_prefix("+0b") {
+                            (1.0, stripped)
                         } else {
                             (1.0, &num_str[2..])
                         };
@@ -1935,10 +1935,10 @@ fn pairs_to_expr_inner(pairs: Pairs<Rule>, preserve_comments: bool) -> AnyhowRes
                         sign * parsed as f64
                     } else if num_str.starts_with("0x") || num_str.starts_with("-0x") || num_str.starts_with("+0x") {
                         // Hexadecimal number
-                        let (sign, digits) = if num_str.starts_with("-0x") {
-                            (-1.0, &num_str[3..])
-                        } else if num_str.starts_with("+0x") {
-                            (1.0, &num_str[3..])
+                        let (sign, digits) = if let Some(stripped) = num_str.strip_prefix("-0x") {
+                            (-1.0, stripped)
+                        } else if let Some(stripped) = num_str.strip_prefix("+0x") {
+                            (1.0, stripped)
                         } else {
                             (1.0, &num_str[2..])
                         };

--- a/blots-core/src/grammar.pest
+++ b/blots-core/src/grammar.pest
@@ -5,7 +5,12 @@ inline_comment = _{ "//" ~ (!plain_newline ~ ANY)* }
 comment    = @{ "//" ~ (!plain_newline ~ ANY)* }
 eol_comment = @{ "//" ~ (!plain_newline ~ ANY)* }
 
-number  = @{ (integer ~ ("_"+ ~ integer)* ~ ("." ~ ASCII_DIGIT+)? | !integer ~ "." ~ ASCII_DIGIT+) ~ (^"e" ~ integer)? }
+number  = @{ binary_number | hex_number | decimal_number }
+binary_number = _{ ("+" | "-")? ~ "0b" ~ binary_digits }
+hex_number = _{ ("+" | "-")? ~ "0x" ~ hex_digits }
+decimal_number = _{ (integer ~ ("_"+ ~ integer)* ~ ("." ~ ASCII_DIGIT+)? | !integer ~ "." ~ ASCII_DIGIT+) ~ (^"e" ~ integer)? }
+binary_digits = _{ ("0" | "1")+ ~ ("_"+ ~ ("0" | "1")+)* }
+hex_digits = _{ (ASCII_DIGIT | 'a'..'f' | 'A'..'F')+ ~ ("_"+ ~ (ASCII_DIGIT | 'a'..'f' | 'A'..'F')+)* }
 integer = _{ ("+" | "-")? ~ ASCII_DIGIT+ }
 
 bool = { "true" | "false" }


### PR DESCRIPTION
# Add Binary and Hexadecimal Numeric Literal Support

This PR adds support for binary (`0b`) and hexadecimal (`0x`) numeric literals to the Blots language.

## Changes

- **Grammar updates**: Extended the number parsing rules to support binary (`0b`) and hex (`0x`) prefixes
- **Parser/evaluator**: Updated `pairs_to_expr_inner` to parse and evaluate binary/hex literals, including support for:
  - Positive and negative numbers (`+0b1010`, `-0xFF`)
  - Underscore separators for readability (`0b1010_1010`, `0xFF_FF`)
  - Case-insensitive hex digits (`0xFF`, `0xff`, `0xFf`)

## Testing

Comprehensive test coverage includes:
- Basic parsing of binary and hex literals
- Sign handling (positive, negative, explicit positive)
- Underscore separators
- Integration with arithmetic operations and comparisons
- Usage in lists and other data structures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces binary and hexadecimal numeric literal support across grammar and parsing.
> 
> - Updates `grammar.pest` to split `number` into `binary_number`/`hex_number`/`decimal_number`, with `binary_digits`/`hex_digits`, underscore separators, and case-insensitive hex
> - Extends `pairs_to_expr_inner` to parse `0b`/`0x` numbers (handles `+`/`-`, underscores) and emit clear errors for invalid bases; decimal path unchanged
> - Adds tests covering literals, sign handling, underscores, arithmetic/comparisons, and usage in lists
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 554b23484b62968d3b3abb300bb957a74e800b85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->